### PR TITLE
Simplify tests by moving boilerplate code into Intersight client module

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request_target]
 name: Terratest
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-cisco-modules/terraform-intersight-pools-ip
 go 1.18
 
 require (
-	github.com/cgascoig/intersight-simple-go v0.1.0
+	github.com/cgascoig/intersight-simple-go v0.2.0
 	github.com/gruntwork-io/terratest v0.40.22
 	github.com/maxatome/go-testdeep v1.12.0
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cgascoig/intersight-simple-go v0.1.0 h1:98+w3+XbSL6gy5lw0DnZYtQ1udv73o+0VBJoxnYytUM=
 github.com/cgascoig/intersight-simple-go v0.1.0/go.mod h1:uJXALl+vQe/rUo43Zxk4GOoObhnu/7Uapqx6JRdmwYg=
+github.com/cgascoig/intersight-simple-go v0.2.0 h1:J8VoKVXSL+l7s8jklEUa/c8o4InImdZBoaIUyKqrFOI=
+github.com/cgascoig/intersight-simple-go v0.2.0/go.mod h1:uJXALl+vQe/rUo43Zxk4GOoObhnu/7Uapqx6JRdmwYg=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
Simplify Terratest tests by:

- moving a lot of the Intersight client boilerplate out of the test and into the Intersight module (under a new assert package)
- remove go-testdeep and perform validation inside the Intersight module
- specify expected result as JSON for simpler syntax (could also be moved out to a separate file in the future)